### PR TITLE
 Add "transform-object-assign" plugin in babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["es2015"],
   "plugins": [
-    "add-module-exports"
+    "add-module-exports",
+    "transform-object-assign"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-core": "6.21.0",
     "babel-loader": "6.2.10",
     "babel-plugin-add-module-exports": "0.2.1",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "6.18.0",
     "babel-register": "6.18.0",
     "chai": "3.5.0",


### PR DESCRIPTION
I had a problem with object assign on IE 11. Adding this plugin doesn't cost a lot but fix it.